### PR TITLE
Handle new Zint API >= 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       - sudo apt-get -y install pkgconf libqrencode-dev
       - sudo apt-get -y install barcode
       # Install zint from source
-      - wget https://downloads.sourceforge.net/project/zint/zint/2.6.5/zint-2.6.5.tar.gz && tar xzf zint-2.6.5.tar.gz && ( cd zint-2.6.5 && mkdir build && cd build && cmake .. && make && sudo make install )
+      - wget https://downloads.sourceforge.net/project/zint/zint/2.12.0/zint-2.12.0-src.tar.gz && tar xzf zint-2.12.0-src.tar.gz && ( cd zint-2.12.0-src && mkdir build && cd build && cmake .. && make && sudo make install )
       - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
     before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif ()
 find_package (ZLIB 1.2 QUIET)
 find_package (GnuBarcode 0.98 QUIET)
 find_package (LibQrencode 3.4 QUIET)
-find_package (LibZint 2.6 EXACT QUIET)
+find_package (LibZint 2.6 QUIET)
 # Unit testing support
 find_package (Qt5Test 5.6 QUIET)
 

--- a/backends/barcode/Backends.cpp
+++ b/backends/barcode/Backends.cpp
@@ -184,12 +184,19 @@ namespace glabels
 			glbarcode::Factory::registerType( "zint::ausrd",     Zint::AusRD::create );
 			glbarcode::Factory::registerType( "zint::aztec",     Zint::Aztec::create );
 			glbarcode::Factory::registerType( "zint::azrun",     Zint::Azrun::create );
+			#if LIBZINT_VERSION >= 21101
+			glbarcode::Factory::registerType( "zint::bc412",     Zint::Bc412::create );
+			glbarcode::Factory::registerType( "zint::cepnet",    Zint::Cepnet::create );
+			#endif
 			glbarcode::Factory::registerType( "zint::cbr",       Zint::Cbr::create );
+			glbarcode::Factory::registerType( "zint::cblockf",   Zint::Cblockf::create );
+			glbarcode::Factory::registerType( "zint::channel",   Zint::Channel::create );
 			glbarcode::Factory::registerType( "zint::code1",     Zint::Code1::create );
 			glbarcode::Factory::registerType( "zint::code11",    Zint::Code11::create );
 			glbarcode::Factory::registerType( "zint::c16k",      Zint::C16k::create );
 			glbarcode::Factory::registerType( "zint::c25m",      Zint::C25m::create );
 			glbarcode::Factory::registerType( "zint::c25i",      Zint::C25i::create );
+			glbarcode::Factory::registerType( "zint::c25ind",    Zint::C25ind::create );
 			glbarcode::Factory::registerType( "zint::c25dl",     Zint::C25dl::create );
 			glbarcode::Factory::registerType( "zint::code32",    Zint::Code32::create );
 			glbarcode::Factory::registerType( "zint::code39",    Zint::Code39::create );
@@ -202,10 +209,18 @@ namespace glabels
 			glbarcode::Factory::registerType( "zint::dmtx",      Zint::Dmtx::create );
 			glbarcode::Factory::registerType( "zint::dpl",       Zint::Dpl::create );
 			glbarcode::Factory::registerType( "zint::dpi",       Zint::Dpi::create );
+			glbarcode::Factory::registerType( "zint::dotcode",   Zint::Dotcode::create );
+			#if LIBZINT_VERSION >= 20901
+			glbarcode::Factory::registerType( "zint::dpd",       Zint::Dpd::create );
+			#endif
 			glbarcode::Factory::registerType( "zint::kix",       Zint::Kix::create );
 			glbarcode::Factory::registerType( "zint::ean",       Zint::Ean::create );
+			glbarcode::Factory::registerType( "zint::ean14",     Zint::Ean14::create );
+			glbarcode::Factory::registerType( "zint::fim",       Zint::Fim::create );
+			glbarcode::Factory::registerType( "zint::flat",      Zint::Flat::create );
 			glbarcode::Factory::registerType( "zint::gmtx",      Zint::Gmtx::create );
 			glbarcode::Factory::registerType( "zint::gs1-128",   Zint::Gs1128::create );
+			glbarcode::Factory::registerType( "zint::hanxin",    Zint::Hanxin::create );
 			glbarcode::Factory::registerType( "zint::rss14",     Zint::Rss14::create );
 			glbarcode::Factory::registerType( "zint::rssltd",    Zint::Rssltd::create );
 			glbarcode::Factory::registerType( "zint::rssexp",    Zint::Rssexp::create );
@@ -218,6 +233,7 @@ namespace glabels
 			glbarcode::Factory::registerType( "zint::hibcqr",    Zint::Hibcqr::create );
 			glbarcode::Factory::registerType( "zint::hibcpdf",   Zint::Hibcpdf::create );
 			glbarcode::Factory::registerType( "zint::hibcmpdf",  Zint::Hibcmpdf::create );
+			glbarcode::Factory::registerType( "zint::hibcblkf",  Zint::Hibcblkf::create );
 			glbarcode::Factory::registerType( "zint::hibcaz",    Zint::Hibcaz::create );
 			glbarcode::Factory::registerType( "zint::i25",       Zint::I25::create );
 			glbarcode::Factory::registerType( "zint::isbn",      Zint::Isbn::create );
@@ -238,13 +254,24 @@ namespace glabels
 			glbarcode::Factory::registerType( "zint::pharma2",   Zint::Pharma2::create );
 			glbarcode::Factory::registerType( "zint::pzn",       Zint::Pzn::create );
 			glbarcode::Factory::registerType( "zint::qr",        Zint::Qr::create );
+			#if LIBZINT_VERSION >= 20700
+			glbarcode::Factory::registerType( "zint::rmqr",      Zint::Rmqr::create );
+			#endif
 			glbarcode::Factory::registerType( "zint::rm4",       Zint::Rm4::create );
+			glbarcode::Factory::registerType( "zint::rm4sm",     Zint::Rm4sm::create );
+			#if LIBZINT_VERSION >= 21200
+			glbarcode::Factory::registerType( "zint::rm2dm",     Zint::Rm2dm::create );
+			#endif
 			glbarcode::Factory::registerType( "zint::tele",      Zint::Tele::create );
 			glbarcode::Factory::registerType( "zint::telex",     Zint::Telex::create );
 			glbarcode::Factory::registerType( "zint::upc-a",     Zint::UpcA::create );
 			glbarcode::Factory::registerType( "zint::upc-e",     Zint::UpcE::create );
+			#if LIBZINT_VERSION >= 21200
+			glbarcode::Factory::registerType( "zint::upus10",    Zint::UpuS10::create );
+			#endif
 			glbarcode::Factory::registerType( "zint::usps",      Zint::Usps::create );
 			glbarcode::Factory::registerType( "zint::pls",       Zint::Pls::create );
+			glbarcode::Factory::registerType( "zint::vin",       Zint::Vin::create );
 
 			registerStyle( "ausp", "zint", tr("Australia Post Standard"),
 			               false, false, true, false, "12345678901234567890123", true, 23 );
@@ -261,38 +288,55 @@ namespace glabels
 			registerStyle( "aztec", "zint", tr("Aztec Code"),
 			               false, false, true, false, "1234567890", true, 10 );
           
-			registerStyle( "azrun", "zint", tr("Aztec Rune"),
+			registerStyle( "azrun", "zint", tr("Aztec Runes"),
 			               false, false, true, false, "255", true, 3 );
 
+			#if LIBZINT_VERSION >= 21101
+			registerStyle( "bc412", "zint", tr("BC412 (SEMI TI-95)"),
+			               true, true, true, false, "12345678", true, 8 );
+
+			registerStyle( "cepnet", "zint", tr("CEPNet (Brazilian Post)"),
+			               false, false, true, false, "12345678", true, 8 );
+			#endif
+
+			registerStyle( "channel", "zint", tr("Channel Code"),
+			               true, true, false, false, "00", true, 2 );
+
 			registerStyle( "cbr", "zint", tr("Codabar"),
-			               true, true, true, false, "ABCDABCDAB", true, 10 );
+			               true, true, true, true, "A00000000B", true, 10 );
+
+			registerStyle( "cblockf", "zint", tr("Codablock-F"),
+			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "code1", "zint", tr("Code One"), 
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "code11", "zint", tr("Code 11"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
           
 			registerStyle( "c16k", "zint", tr("Code 16K"),
 			               false, false, true, false, "0000000000", true, 10 );
           
-			registerStyle( "c25m", "zint", tr("Code 2 of 5 Matrix"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			registerStyle( "c25m", "zint", tr("Code 2 of 5 Standard"),
+			               true, true, true, true, "0000000000", true, 10 );
           
 			registerStyle( "c25i", "zint", tr("Code 2 of 5 IATA"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
+
+			registerStyle( "c25ind", "zint", tr("Code 2 of 5 Industrial"),
+			               true, true, true, true, "0000000000", true, 10 );
           
 			registerStyle( "c25dl", "zint", tr("Code 2 of 5 Data Logic"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
 			registerStyle( "code32", "zint", tr("Code 32 (Italian Pharmacode)"), 
 			               true, true, true, false, "12345678", true, 8 );
 
 			registerStyle( "code39", "zint", tr("Code 39"),
-			               true, true, false, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
           
 			registerStyle( "code39e", "zint", tr("Code 39 Extended"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
 			registerStyle( "code49", "zint", tr("Code 49"),
 			               false, false, true, false, "0000000000", true, 10 );
@@ -317,36 +361,56 @@ namespace glabels
           
 			registerStyle( "dpi", "zint", tr("Deutsche Post Identcode"),
 			               true, true, true, false, "12345678901", true, 11 );
-          
-			registerStyle( "kix", "zint", tr("Dutch Post KIX Code"),
+
+			registerStyle( "dotcode", "zint", tr("DotCode"),
 			               false, false, true, false, "0000000000", true, 10 );
 
+			#if LIBZINT_VERSION >= 20901
+			registerStyle( "dpd", "zint", tr("DPD Code"),
+			               true, true, true, false, "000000000000000000000000000", true, 27 );
+			#endif
+
+			registerStyle( "kix", "zint", tr("Dutch Post KIX Code"),
+			               false, false, false, false, "0000000000", true, 10 );
+
 			registerStyle( "ean", "zint", tr("EAN"),
+			               true, true, true, false, "123456789012", false, 12 );
+
+			registerStyle( "ean14", "zint", tr("EAN-14"),
 			               true, true, true, false, "1234567890123", false, 13 );
+
+			registerStyle( "fim", "zint", tr("FIM (Facing ID Mark)"),
+			               false, false, false, false, "A", false, 1 );
+
+			registerStyle( "flat", "zint", tr("Flattermarken"),
+			               false, false, false, false, "11111111", false, 8 );
 
 			registerStyle( "gmtx", "zint", tr("Grid Matrix"), 
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "gs1-128", "zint", tr("GS1-128"),
-			               true, true, true, false, "[01]12345678901234", false, 18 );
+			               true, true, true, false, "[01]12345678901231", false, 18 );
 
-			registerStyle( "rss14", "zint", tr("GS1 DataBar-14"),
+			registerStyle( "rss14", "zint", tr("GS1 DataBar Omnidirectional"),
 			               true, true, true, false, "1234567890123", true, 13 );
           
-			registerStyle( "rssltd", "zint", "GS1 DataBar-14 Limited", 
+			registerStyle( "rssltd", "zint", "GS1 DataBar Limited",
 			               true, true, true, false, "1234567890123", true, 13 );
           
-			registerStyle( "rssexp", "zint", "GS1 DataBar Extended", 
-			               true, true, true, false, "[01]12345678901234", false, 18 );
+			registerStyle( "rssexp", "zint", "GS1 DataBar Expanded",
+			               true, true, true, false, "[01]12345678901231", false, 18 );
           
-			registerStyle( "rsss", "zint", tr("GS1 DataBar-14 Stacked"),
+			registerStyle( "rsss", "zint", tr("GS1 DataBar Stacked"),
 			               false, false, true, false, "0000000000", true, 10 );
 
-			registerStyle( "rssso", "zint", tr("GS1 DataBar-14 Stacked Omni."),
+			registerStyle( "rssso", "zint", tr("GS1 DataBar Stacked Omni."),
 			               false, false, true, false, "0000000000", true, 10 );
 
-			registerStyle( "rssse", "zint", tr("GS1 DataBar Extended Stacked"),
-			               false, false, true, false, "[01]12345678901234", false, 18 );
+			registerStyle( "rssse", "zint", tr("GS1 DataBar Expanded Stacked"),
+			               false, false, true, false, "[01]12345678901231", false, 18 );
+
+			registerStyle( "hanxin", "zint", tr("Han Xin"),
+			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "hibc128", "zint", tr("HIBC Code 128"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -363,14 +427,17 @@ namespace glabels
 			registerStyle( "hibcpdf", "zint", tr("HIBC PDF417"),
 			               false, false, true, false, "0000000000", true, 10 );
 
-			registerStyle( "hibcmpdf", "zint", tr("HIBC Micro PDF417"),
+			registerStyle( "hibcmpdf", "zint", tr("HIBC MicroPDF417"),
+			               false, false, true, false, "0000000000", true, 10 );
+
+			registerStyle( "hibcblkf", "zint", tr("HIBC Codablock-F"),
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "hibcaz", "zint", tr("HIBC Aztec Code"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "i25", "zint", tr("Interleaved 2 of 5"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
 			registerStyle( "isbn", "zint", tr("ISBN"),
 			               true, true, true, false, "123456789", false, 9 );
@@ -385,49 +452,62 @@ namespace glabels
 			               true, true, true, false, "123456", false, 6 );
 
 			registerStyle( "logm", "zint", tr("LOGMARS"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
 			registerStyle( "maxi", "zint", tr("Maxicode"),
-			               false, false, false, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10 );
 
-			registerStyle( "mpdf", "zint", tr("Micro PDF417"),
+			registerStyle( "mpdf", "zint", tr("MicroPDF417"),
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "mqr", "zint", tr("Micro QR Code"),
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "msi", "zint", tr("MSI Plessey"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
-			registerStyle( "nve", "zint", tr("NVE-18"),
+			registerStyle( "nve", "zint", tr("NVE-18 (SSCC-18)"),
 			               true, true, true, false, "12345678901234567", false, 17 );
 
 			registerStyle( "pdf", "zint", tr("PDF417"),
 			               false, false, true, false, "0000000000", true, 10 );
 
-			registerStyle( "pdft", "zint", tr("PDF417 Truncated"),
+			registerStyle( "pdft", "zint", tr("PDF417 Compact"),
 			               false, false, true, false, "0000000000", true, 10 );
 
 			registerStyle( "plan", "zint", tr("PLANET"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "00000000000", true, 11 );
 
-			registerStyle( "postnet", "zint", tr("PostNet"),
-			               true, true, true, false, "0000000000", true, 10 );
+			registerStyle( "postnet", "zint", tr("POSTNET"),
+			               false, false, true, false, "00000000000", true, 11 );
 
 			registerStyle( "pharma", "zint", tr("Pharmacode"),
-			               false, false, true, false, "123456", false, 6 );
+			               false, false, false, false, "123456", false, 6 );
 
 			registerStyle( "pharma2", "zint", tr("Pharmacode 2-track"),
-			               false, false, true, false, "12345678", false, 8 );
+			               false, false, false, false, "12345678", false, 8 );
 
-			registerStyle( "pzn", "zint", tr("Pharmazentral Nummer (PZN)"),
-			               true, true, true, false, "123456", false, 6 );
+			registerStyle( "pzn", "zint", tr("Pharmazentralnummer (PZN)"),
+			               true, true, true, false, "1234567", false, 7 );
 
 			registerStyle( "qr", "zint", tr("QR Code"),
-			               true, true, true, false, "0000000000", true, 10 );
-
-			registerStyle( "rm4", "zint", tr("Royal Mail 4-State"),
 			               false, false, true, false, "0000000000", true, 10 );
+
+			#if LIBZINT_VERSION >= 20700
+			registerStyle( "rmqr", "zint", tr("rMQR (Rectangular Micro QR)"),
+			               false, false, true, false, "0000000000", true, 10 );
+			#endif
+
+			registerStyle( "rm4", "zint", tr("Royal Mail 4-State Customer"),
+			               false, false, true, false, "0000000000", true, 10 );
+
+			registerStyle( "rm4sm", "zint", tr("Royal Mail 4-State Mailmark"),
+			               false, false, true, false, "01000000000000000AA00AA0A", true, 25 );
+
+			#if LIBZINT_VERSION >= 21200
+			registerStyle( "rm2dm", "zint", tr("Royal Mail 2-D Mailmark"),
+			               false, false, true, false, "012100123412345678AB19XY1A 0", true, 28 );
+			#endif
 
 			registerStyle( "tele", "zint", tr("Telepen"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -435,17 +515,25 @@ namespace glabels
 			registerStyle( "telex", "zint", tr("Telepen Numeric"),
 			               true, true, true, false, "0000000000", true, 10 );
 
+			registerStyle( "pls", "zint", tr("UK Plessey"),
+			               true, true, true, false, "0000000000", true, 10 );
+
 			registerStyle( "upc-a", "zint", tr("UPC-A"), 
 			               true, true, true, false, "12345678901", false, 11 );
           
 			registerStyle( "upc-e", "zint", tr("UPC-E"), 
 			               true, true, true, false, "1234567", false, 7 );
-          
-			registerStyle( "usps", "zint", tr("USPS One Code"),
+
+			#if LIBZINT_VERSION >= 21200
+			registerStyle( "upus10", "zint", tr("UPU S10"),
+			               true, true, true, false, "EE876543216CA", false, 13 );
+			#endif
+
+			registerStyle( "usps", "zint", tr("USPS Intelligent Mail"),
 			               false, false, true, false, "12345678901234567890", true, 20 );
 
-			registerStyle( "pls", "zint", tr("UK Plessey"),
-			               true, true, true, false, "0000000000", true, 10 );
+			registerStyle( "vin", "zint", tr("VIN (Vehicle ID Number)"),
+			               true, true, true, false, "12345678701234567", false, 27 );
 #endif // HAVE_ZINT
 
 		}

--- a/backends/barcode/CMakeLists.txt
+++ b/backends/barcode/CMakeLists.txt
@@ -19,6 +19,7 @@ endif ()
 
 if (${LIBZINT_FOUND})
   add_definitions (-DHAVE_ZINT=1)
+  add_definitions (-DHAVE_ZINT=1 -DLIBZINT_VERSION=${LIBZINT_VERSION})
   set (OPTIONAL_ZINT ZINT::ZINT)
 else ()
   set (OPTIONAL_ZINT "")

--- a/backends/barcode/Zint.h
+++ b/backends/barcode/Zint.h
@@ -42,8 +42,11 @@ namespace glabels
 			{
 			protected:
 				int symbology;
-			
-			
+				int option_2;
+
+
+				Base();
+
 				bool validate( const std::string& rawData ) override;
 
 				void vectorize( const std::string& encodedData,
@@ -133,6 +136,19 @@ namespace glabels
 
 
 			/**
+			 * Channel Barcode
+			 */
+			class Channel : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
 			 * Cbr Barcode
 			 */
 			class Cbr : public Base
@@ -140,6 +156,19 @@ namespace glabels
 			public:
 				static Barcode* create();
 			
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Codeblock-F Barcode
+			 */
+			class Cblockf : public Base
+			{
+			public:
+				static Barcode* create();
+
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};
@@ -205,6 +234,19 @@ namespace glabels
 			public:
 				static Barcode* create();
 			
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Code 2 of 5 Industrial Barcode
+			 */
+			class C25ind : public Base
+			{
+			public:
+				static Barcode* create();
+
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};
@@ -367,6 +409,34 @@ namespace glabels
 
 
 			/**
+			 * DotCode Barcode
+			 */
+			class Dotcode : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			#if LIBZINT_VERSION >= 20901
+			/**
+			 * DPD Code Barcode
+			 */
+			class Dpd : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
+
+
+			/**
 			 * Kix Barcode
 			 */
 			class Kix : public Base
@@ -387,6 +457,58 @@ namespace glabels
 			public:
 				static Barcode* create();
 			
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * EAN-14 Barcode
+			 */
+			class Ean14 : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Facing Identification Mark Barcode
+			 */
+			class Fim : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Flattermarken Barcode
+			 */
+			class Flat : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Han Xin Barcode
+			 */
+			class Hanxin : public Base
+			{
+			public:
+				static Barcode* create();
+
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};
@@ -465,6 +587,19 @@ namespace glabels
 			public:
 				static Barcode* create();
 			
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * HIBC Codablock-F Barcode
+			 */
+			class Hibcblkf : public Base
+			{
+			public:
+				static Barcode* create();
+
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};
@@ -821,6 +956,36 @@ namespace glabels
 			};
 
 
+			#if LIBZINT_VERSION >= 21101
+			/**
+			 * BC412 (SEMI T1-95) Barcode
+			 */
+			class Bc412 : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
+
+
+			#if LIBZINT_VERSION >= 21101
+			/**
+			 * CEPNet Barcode
+			 */
+			class Cepnet : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
+
+
 			/**
 			 * Pdf Barcode
 			 */
@@ -860,6 +1025,21 @@ namespace glabels
 			};
 
 
+			#if LIBZINT_VERSION >= 20700
+			/**
+			 * rMQR Barcode
+			 */
+			class Rmqr : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
+
+
 			/**
 			 * Rm4 Barcode
 			 */
@@ -871,6 +1051,34 @@ namespace glabels
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};
+
+
+			/**
+			 * Royal Mail 4-State Mailmark Barcode
+			 */
+			class Rm4sm : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			#if LIBZINT_VERSION >= 21200
+			/**
+			 * Royal Mail 2-D Mailmark Barcode
+			 */
+			class Rm2dm : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
 
 
 			/**
@@ -899,6 +1107,21 @@ namespace glabels
 			};
 
 
+			#if LIBZINT_VERSION >= 21200
+			/**
+			 * UPU S10 Barcode
+			 */
+			class UpuS10 : public Base
+			{
+			public:
+				static Barcode* create();
+
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+			#endif
+
+
 			/**
 			 * Usps Barcode
 			 */
@@ -920,6 +1143,19 @@ namespace glabels
 			public:
 				static Barcode* create();
 			
+			protected:
+				std::string encode( const std::string& cookedData ) override;
+			};
+
+
+			/**
+			 * Vehicle Identification Number Barcode
+			 */
+			class Vin : public Base
+			{
+			public:
+				static Barcode* create();
+
 			protected:
 				std::string encode( const std::string& cookedData ) override;
 			};

--- a/docs/BUILD-INSTRUCTIONS-LINUX.md
+++ b/docs/BUILD-INSTRUCTIONS-LINUX.md
@@ -41,9 +41,9 @@ _Zint (Optional)_
 
 Install zint from source:
 ```
-wget https://downloads.sourceforge.net/project/zint/zint/2.6.3/zint-2.6.3_final.tar.gz
-tar xzf zint-2.6.3_final.tar.gz
-cd zint-2.6.3.src/
+wget https://downloads.sourceforge.net/project/zint/zint/2.12.0/zint-2.12.0-src.tar.gz
+tar xzf zint-2.12.0-src.tar.gz
+cd zint-2.12.0-src/
 mkdir build && cd build && cmake .. && make
 sudo make install
 ```

--- a/glbarcode/Barcode.cpp
+++ b/glbarcode/Barcode.cpp
@@ -174,9 +174,9 @@ namespace glbarcode
 	}
 
 
-	void Barcode::addText( double x, double y, double size, const std::string& text )
+	void Barcode::addText( double x, double y, double size, const std::string& text, int halign )
 	{
-		d->mPrimitives.push_back( new DrawingPrimitiveText( x, y, size, text ) );
+		d->mPrimitives.push_back( new DrawingPrimitiveText( x, y, size, text, halign ) );
 	}
 
 

--- a/glbarcode/Barcode.h
+++ b/glbarcode/Barcode.h
@@ -215,12 +215,13 @@ namespace glbarcode
 		 *
 		 * @image html figure-primitive-text.svg "Text primitive properties"
 		 *
-		 * @param[in] x     X coordinate of text's origin (points)
-		 * @param[in] y     Y coordinate of text's origin (points)
-		 * @param[in] size  Font size of text (points)
-		 * @param[in] text  Text
+		 * @param[in] x       X coordinate of text's origin (points)
+		 * @param[in] y       Y coordinate of text's origin (points)
+		 * @param[in] size    Font size of text (points)
+		 * @param[in] text    Text
+		 * @param[in] halign  Horizontal alignment (center 0, left 1, right 2)
 		 */
-		void addText( double x, double y, double size, const std::string& text );
+		void addText( double x, double y, double size, const std::string& text, int halign = 0 );
 
 
 		/**

--- a/glbarcode/DrawingPrimitives.cpp
+++ b/glbarcode/DrawingPrimitives.cpp
@@ -81,8 +81,8 @@ namespace glbarcode
 
 
 
-	DrawingPrimitiveText::DrawingPrimitiveText( double x, double y, double size, const std::string& text )
-		: DrawingPrimitive( x, y ), mSize(size), mText(text)
+	DrawingPrimitiveText::DrawingPrimitiveText( double x, double y, double size, const std::string& text, int halign )
+		: DrawingPrimitive( x, y ), mSize(size), mText(text), mHalign(halign)
 	{
 	}
 
@@ -96,6 +96,12 @@ namespace glbarcode
 	const std::string& DrawingPrimitiveText::text() const
 	{
 		return mText;
+	}
+
+
+	int DrawingPrimitiveText::halign() const
+	{
+		return mHalign;
 	}
 
 

--- a/glbarcode/DrawingPrimitives.h
+++ b/glbarcode/DrawingPrimitives.h
@@ -163,12 +163,13 @@ namespace glbarcode
 		/**
 		 * Text constructor
 		 *
-		 * @param[in] x    X coordinate of text's origin (points)
-		 * @param[in] y    Y coordinate of text's origin (points)
-		 * @param[in] size Font size of text (points)
-		 * @param[in] text Text
+		 * @param[in] x      X coordinate of text's origin (points)
+		 * @param[in] y      Y coordinate of text's origin (points)
+		 * @param[in] size   Font size of text (points)
+		 * @param[in] text   Text
+		 * @param[in] halign Horizontal alignment (center 0, left 1, right 2)
 		 */
-		DrawingPrimitiveText( double x, double y, double size, const std::string& text );
+		DrawingPrimitiveText( double x, double y, double size, const std::string& text, int halign = 0 );
 
 		/**
 		 * Get font size (points).
@@ -180,9 +181,15 @@ namespace glbarcode
 		 */
 		const std::string& text() const;
 
+		/**
+		 * Get horizontal alignment.
+		 */
+		int halign() const;
+
 	private:
 		double       mSize;    /**< Font size of text (points). */
 		std::string  mText;    /**< Text. */
+		int          mHalign;  /**< Horizontal alignment. */
 	};
 
 

--- a/glbarcode/QtRenderer.cpp
+++ b/glbarcode/QtRenderer.cpp
@@ -30,6 +30,7 @@
 namespace
 {
 	const double FONT_SCALE = 0.75;
+	const double MIN_POINT_SIZE = 0.4; // Less than ~0.37 causes issues for QFontMetricsF
 }
 
 
@@ -122,7 +123,7 @@ namespace glbarcode
 	}
 
 
-	void QtRenderer::drawText( double x, double y, double size, const std::string& text )
+	void QtRenderer::drawText( double x, double y, double size, const std::string& text, int halign )
 	{
 		if ( d->painter )
 		{
@@ -131,10 +132,18 @@ namespace glbarcode
 			QFont font;
 			font.setStyleHint( QFont::Monospace );
 			font.setFamily( "monospace" );
-			font.setPointSizeF( FONT_SCALE*size );
+			font.setPointSizeF( std::max( FONT_SCALE*size, MIN_POINT_SIZE ) );
 
 			QFontMetricsF fm( font );
-			double xCorner = x - fm.width( QString::fromStdString(text) )/2.0;
+			double xCorner = x;
+			if ( halign == 0 ) // Center
+			{
+				xCorner -= fm.width( QString::fromStdString(text) )/2.0;
+			}
+			else if ( halign == 2 ) // Right
+			{
+				xCorner -= fm.width( QString::fromStdString(text) );
+			}
 			double yCorner = y - fm.ascent();
 		
 			QTextLayout layout( QString::fromStdString(text), font );
@@ -151,7 +160,7 @@ namespace glbarcode
 		if ( d->painter )
 		{
 			d->painter->setPen( QPen( d->color, w ) );
-			d->painter->setBrush( Qt::NoBrush );
+			d->painter->setBrush( w ? Qt::NoBrush : QBrush( d->color ) );
 		
 			d->painter->drawEllipse( QPointF(x, y), r, r );
 		}

--- a/glbarcode/QtRenderer.h
+++ b/glbarcode/QtRenderer.h
@@ -76,7 +76,7 @@ namespace glbarcode
 		void drawEnd() override;
 		void drawLine( double x, double y, double w, double h ) override;
 		void drawBox( double x, double y, double w, double h ) override;
-		void drawText( double x, double y, double size, const std::string& text ) override;
+		void drawText( double x, double y, double size, const std::string& text, int halign = 0 ) override;
 		void drawRing( double x, double y, double r, double w ) override;
 		void drawHexagon( double x, double y, double h ) override;
 

--- a/glbarcode/Renderer.cpp
+++ b/glbarcode/Renderer.cpp
@@ -41,7 +41,7 @@ void glbarcode::Renderer::render( double w, double h, const std::list<DrawingPri
 		}
 		else if ( auto* text = dynamic_cast<DrawingPrimitiveText*>(*primitive) )
 		{
-			drawText( text->x(), text->y(), text->size(), text->text() );
+			drawText( text->x(), text->y(), text->size(), text->text(), text->halign() );
 		}
 		else if ( auto* ring = dynamic_cast<DrawingPrimitiveRing*>(*primitive) )
 		{

--- a/glbarcode/Renderer.h
+++ b/glbarcode/Renderer.h
@@ -132,7 +132,7 @@ namespace glbarcode
 		 * @param[in] size Font size of text (points)
 		 * @param[in] text Text
 		 */
-		virtual void drawText( double x, double y, double size, const std::string& text ) = 0;
+		virtual void drawText( double x, double y, double size, const std::string& text, int halign = 0 ) = 0;
 
 
 		/**

--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -235,7 +235,7 @@ namespace glabels
 		///
 		Distance Model::w() const
 		{
-			if ( auto* frame = mTmplate.frames().constFirst() )
+			if ( auto* frame = !mTmplate.frames().isEmpty() ? mTmplate.frames().constFirst() : nullptr )
 			{
 				return mRotate ? frame->h() : frame->w();
 			}
@@ -251,7 +251,7 @@ namespace glabels
 		///
 		Distance Model::h() const
 		{
-			if ( auto* frame = mTmplate.frames().constFirst() )
+			if ( auto* frame = !mTmplate.frames().isEmpty() ? mTmplate.frames().constFirst() : nullptr )
 			{
 				return mRotate ? frame->w() : frame->h();
 			}

--- a/model/ModelBarcodeObject.cpp
+++ b/model/ModelBarcodeObject.cpp
@@ -49,6 +49,7 @@ namespace glabels
 			const Distance pad = Distance::pt(4);
 			const Distance minW = Distance::pt(18);
 			const Distance minH = Distance::pt(18);
+			const double MIN_POINT_SIZE = 0.4; // Less than ~0.37 causes issues for QFontMetricsF
 		}
 
 
@@ -508,7 +509,7 @@ namespace glabels
 			{
 				double scaleX = wPts / textRect.width();
 				double scaleY = hPts / textRect.height();
-				font.setPointSizeF( 6 * std::min( scaleX, scaleY ) );
+				font.setPointSizeF( std::max( 6 * std::min( scaleX, scaleY ), MIN_POINT_SIZE ) );
 			}
 
 			//

--- a/translations/glabels_C.ts
+++ b/translations/glabels_C.ts
@@ -2469,10 +2469,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aztec Rune</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Code One</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2482,10 +2478,6 @@
     </message>
     <message>
         <source>Code 16K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Code 2 of 5 Matrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2541,22 +2533,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>GS1 DataBar-14</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GS1 DataBar-14 Stacked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GS1 DataBar-14 Stacked Omni.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GS1 DataBar Extended Stacked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HIBC Code 128</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2574,10 +2550,6 @@
     </message>
     <message>
         <source>HIBC PDF417</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>HIBC Micro PDF417</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2605,10 +2577,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Micro PDF417</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Micro QR Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2617,23 +2585,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>NVE-18</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>PDF417</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>PDF417 Truncated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>PLANET</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>PostNet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2645,15 +2601,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pharmazentral Nummer (PZN)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>QR Code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Royal Mail 4-State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2665,11 +2613,127 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>USPS One Code</source>
+        <source>UK Plessey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>UK Plessey</source>
+        <source>Aztec Runes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CEPNet (Brazilian Post)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Codablock-F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Code 2 of 5 Standard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GS1 DataBar Stacked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GS1 DataBar Stacked Omni.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GS1 DataBar Expanded Stacked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HIBC MicroPDF417</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MicroPDF417</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NVE-18 (SSCC-18)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF417 Compact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pharmazentralnummer (PZN)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Code 2 of 5 Industrial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DotCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EAN-14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GS1 DataBar Omnidirectional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Han Xin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flattermarken</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DPD Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>POSTNET</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Royal Mail 4-State Mailmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UPU S10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FIM (Facing ID Mark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>rMQR (Rectangular Micro QR)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Royal Mail 4-State Customer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VIN (Vehicle ID Number)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HIBC Codablock-F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Royal Mail 2-D Mailmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BC412 (SEMI TI-95)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Add handling of new Zint API >= 2.7.0 for Zint backend and use latest version (2.12.0) by default (fixes #86 and #160, subsumes PR #164).

 - hack "FindLibZint.cmake" to use `zint -h` to get version;  define `LIBZINT_VERSION`
 - add new API handling in `Zint` in LIBZINT_VERSION >= 20700 define,  leaving 2.6.3 handling unchanged
 - add some new Zint barcodes and adjust style properties of various other Zint barcodes
 - enable check digit handling via Zint `option_2`
 - add horizontal alignment `halign` argument to `Barcode::ahddText()`,  `QtRenderer::drawText()` and `DrawingPrimitiveText::DrawingPrimitiveText()` and use in `QtRenderer::drawText()` to cater for Zint EAN/UPC left/right  text align of outside digits
 - guard against QT infinite loop bug in `QFontMetricsF` when point size < ~0.4 (MIN_POINT_SIZE)
