### PR TITLE
Mac os compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}-${BRANCH}$
 set(LONG_VERSION_STRING "${VERSION_STRING} (${COMMIT_HASH} ${COMMIT_DATE})")
 
 # Auto-generate version file
-configure_file (.version.in VERSION @ONLY)
+configure_file (.version.in VERSION.txt @ONLY)
 
 
 #=======================================

--- a/docs/BUILD-INSTRUCTIONS-MACOS.md
+++ b/docs/BUILD-INSTRUCTIONS-MACOS.md
@@ -5,7 +5,7 @@ gLabels MacOS Build Instructions
 
 ```
 brew install cmake
-brew install qt
+brew install qt@5
 ```
 
 ## Compile and Install

--- a/docs/BUILD-INSTRUCTIONS-MACOS.md
+++ b/docs/BUILD-INSTRUCTIONS-MACOS.md
@@ -11,10 +11,22 @@ brew install qt@5
 ## Compile and Install
 
 <pre>
+export SDKROOT=$(xcrun --show-sdk-path)
+# Detect architecture and set appropriate paths
+if [[ "$(uname -m)" == "arm64" ]]; then
+    # Apple Silicon
+    CMAKE_PATH="/opt/homebrew/bin/cmake"
+    CMAKE_PREFIX_PATH="/opt/homebrew/opt"
+else
+    # Intel
+    CMAKE_PATH="/usr/local/bin/cmake"
+    CMAKE_PREFIX_PATH="/usr/local/opt"
+fi
+
 cd <i>glabels_source_directory</i>
 mkdir build
 cd build
-cmake -D CMAKE_PREFIX_PATH=/usr/local/opt/qt  ..
+$CMAKE_PATH -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH/qt@5 ..
 make
 sudo make install
 </pre>


### PR DESCRIPTION
Modified instructions to allow for compiling on Apple Mac Silicone, renamed version file to VERSION.txt to fix a bug caused by non case sensitive OS's, and account for change in dependancy names