### PR TITLE
Tweaks to glabels-3 text object compatability.

### DIFF
--- a/model/unit_tests/TestXmlLabel.cpp
+++ b/model/unit_tests/TestXmlLabel.cpp
@@ -491,6 +491,10 @@ void TestXmlLabel::parser_3ReadFile()
         //          absolute path, an attempt should be made guess at the relative path (maybe sitting
         //          in the same directory as the glabels file.  For glabels-4 files, the relative path
         //          should be encoded in the file.
+        //
+        // FIX ME:  Y0 of text objects is modified to compensate for differences in the text baseline
+        //          calculations between glabels-3 and glabels-4.  These tests are currently commented
+        //          out.
 
         QFileInfo glabelsFileInfo( QString( "%1/data/glabels-3/crew-orientation-name-tags-7.glabels" ).arg( QString(TEST_DIR) ) );
         QVERIFY( glabelsFileInfo.isReadable() );
@@ -537,7 +541,7 @@ void TestXmlLabel::parser_3ReadFile()
         ModelTextObject* modelTextObject0 = dynamic_cast<ModelTextObject*>( model->objectList()[0] );
         QVERIFY( modelTextObject0 );
         QCOMPARE( modelTextObject0->x0().in(), 0.150603 );
-        QCOMPARE( modelTextObject0->y0().in(), 0.2625 );
+        //QCOMPARE( modelTextObject0->y0().in(), 0.2625 );
         // Width and height set to naturalSize()
         QCOMPARE( modelTextObject0->lockAspectRatio(), false );
         QCOMPARE( modelTextObject0->matrix(), QTransform( 1, 0, 0, 1, 0, 0 ) );
@@ -555,7 +559,7 @@ void TestXmlLabel::parser_3ReadFile()
         ModelTextObject* modelTextObject1 = dynamic_cast<ModelTextObject*>( model->objectList()[1] );
         QVERIFY( modelTextObject1 );
         QCOMPARE( modelTextObject1->x0().in(), 0.150603 );
-        QCOMPARE( modelTextObject1->y0().in(), 0.645 );
+        //QCOMPARE( modelTextObject1->y0().in(), 0.645 );
         // Width and height set to naturalSize()
         QCOMPARE( modelTextObject1->lockAspectRatio(), false );
         QCOMPARE( modelTextObject1->matrix(), QTransform( 1, 0, 0, 1, 0, 0 ) );
@@ -573,7 +577,7 @@ void TestXmlLabel::parser_3ReadFile()
         ModelTextObject* modelTextObject2 = dynamic_cast<ModelTextObject*>( model->objectList()[2] );
         QVERIFY( modelTextObject2 );
         QCOMPARE( modelTextObject2->x0().in(), 0.150603 );
-        QCOMPARE( modelTextObject2->y0().in(), 1.14 );
+        //QCOMPARE( modelTextObject2->y0().in(), 1.14 );
         // Width and height set to naturalSize()
         QCOMPARE( modelTextObject2->lockAspectRatio(), false );
         QCOMPARE( modelTextObject2->matrix(), QTransform( 1, 0, 0, 1, 0, 0 ) );


### PR DESCRIPTION
This commit partially addresses issues in #296.  Due to the fact that glabels-3 and glabels-4 use different underlying technologies for rendering text, a pixel-perfect import can probably never be fully achieved.

This commit focuses on small adjustments to imported text objects to approximate the visual appearance of these objects.

- glabels-3 rendered text at 75% of stated font size, compensate by adjusting font size of imported object.
- Text boxes behave differently in glabels-4 than in glabels-3.  In glabels-4, text boxes must be of a fixed size, so compensate when a variable sized box (when w=0 and/or h=0) is detected and fix the size to the natural text size.
- In glabels-3, the fixed margin size (3pt) was not used in the text baseline calculations.  Compensate by adjusting vertical position of imported text object.