### PR TITLE
Fix updates to PrintView when selecting individual merge records.  (#…

### DIFF
--- a/glabels/MergeTableModel.cpp
+++ b/glabels/MergeTableModel.cpp
@@ -136,9 +136,7 @@ namespace glabels
 
                 bool isChecked = static_cast<Qt::CheckState>(value.toInt()) != Qt::Unchecked;
 
-                mMerge->blockSignals( true );
                 mMerge->setSelected( index.row(), isChecked );
-                mMerge->blockSignals( false );
                 return true;
         }
 

--- a/glabels/PrintView.cpp
+++ b/glabels/PrintView.cpp
@@ -125,6 +125,11 @@ namespace glabels
                 pageSpin->setRange( 1, mRenderer.nPages() );
                 nPagesLabel->setText( QString::number( mRenderer.nPages() ) );
 
+                bool canPrint = mRenderer.nItems();
+                printButton->setEnabled( canPrint );
+                printDescriptionLabel->setEnabled( canPrint );
+                systemDialogButton->setEnabled( canPrint );
+
                 mRenderer.setIPage( pageSpin->value() - 1 ); // Update preview
         }
 

--- a/model/PageRenderer.cpp
+++ b/model/PageRenderer.cpp
@@ -221,7 +221,7 @@ namespace glabels::model
                         mNPages = 0;
                 }
 
-                mNPages = mLastItem/mNItemsPerPage + 1;
+                mNPages = mNItems ? mLastItem/mNItemsPerPage + 1 : 0;
         }
 
 


### PR DESCRIPTION
…325)

- Don't block merge signals in MergeTableModel when record selection check boxes are toggled
- Disable print button when there are zero items to print.